### PR TITLE
Update the fit test_redfish10_api_chassis.py script to use correct list of chassis ids.

### DIFF
--- a/test/fit_tests/tests/redfish10/test_redfish10_api_chassis.py
+++ b/test/fit_tests/tests/redfish10/test_redfish10_api_chassis.py
@@ -11,17 +11,14 @@ import sys
 import subprocess
 sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/fit_tests/common")
 import fit_common
-
-
-# Local methods
-NODECATALOG = fit_common.node_select()
+import json
 
 # Select test group here using @attr
 from nose.plugins.attrib import attr
 @attr(all=True, regression=True, smoke=True)
 
 class redfish10_api_chassis(fit_common.unittest.TestCase):
-    def test_redfish_v1_chassis_links(self):
+    def test_01_redfish_v1_chassis_links(self):
         api_data = fit_common.rackhdapi('/redfish/v1/Chassis')
         self.assertEqual(api_data['status'], 200, 'Incorrect HTTP return code, expected 200, got:' + str(api_data['status']))
         for item in api_data['json']:
@@ -30,14 +27,18 @@ class redfish10_api_chassis(fit_common.unittest.TestCase):
             self.assertNotEqual(item, "", 'Empty JSON Field')
         # test all href member links
         for item in api_data['json']['Members']:
+            if fit_common.VERBOSITY >= 2:
+                print ("Member: {}".format(item))
             link_data = fit_common.rackhdapi(item['@odata.id'])
             self.assertEqual(api_data['status'], 200, 'Incorrect HTTP return code, expected 200, got:' + str(api_data['status']))
 
-    def test_redfish_v1_chassis_id_links(self):
-        #iterate through pre-qualified chassis
+    def test_02_redfish_v1_chassis_id_links(self):
+        #iterate through list of chassis from redfish
         api_data = fit_common.rackhdapi('/redfish/v1/Chassis')
         self.assertEqual(api_data['status'], 200, 'Incorrect HTTP return code')
         for nodeid in api_data['json']['Members']:
+            if fit_common.VERBOSITY >= 2:
+                print ("Node ID: {} ".format(nodeid))
             api_data = fit_common.rackhdapi(nodeid['@odata.id'])
             self.assertEqual(api_data['status'], 200, 'Incorrect HTTP return code, expected 200, got:' + str(api_data['status']))
             # check required fields
@@ -45,7 +46,8 @@ class redfish10_api_chassis(fit_common.unittest.TestCase):
             self.assertIn('Name', api_data['json'], 'Name field not present')
             self.assertGreater(len(api_data['json']['Name']), 0, 'Name field empty')
             chassis_name = api_data['json']['Name']
-
+            if fit_common.VERBOSITY >= 2:
+                print ("Node ID: {} Name: {} ".format(nodeid, chassis_name))
             for item in ['Links', '@odata.id', '@odata.type']:
                 if fit_common.VERBOSITY >= 2:
                     print ("Checking: {0}".format(item))
@@ -57,32 +59,58 @@ class redfish10_api_chassis(fit_common.unittest.TestCase):
                         print ("Checking: {0}".format(item))
                     self.assertGreater(len(api_data['json'][item]), 0, item + ' field empty')
 
-    def test_redfish_v1_chassis_id_power(self):
-        #iterate through pre-qualified chassis
-        for nodeid in NODECATALOG:
-            api_data = fit_common.rackhdapi("/redfish/v1/Chassis/" + nodeid + "/Power")
-            self.assertEqual(api_data['status'], 200, 'Incorrect HTTP return code, expected 200, got:' + str(api_data['status']))
-            # check required fields
-            for item in ['@odata.id', '@odata.type', 'Id']:
-                if fit_common.VERBOSITY >= 2:
-                    print ("Checking: {0}".format(item))
-                self.assertIn(item, api_data['json'], item + ' field not present')
-                if fit_common.VERBOSITY >= 3:
-                    print ("\t {0}".format( api_data['json'][item]))
-                self.assertGreater(len(api_data['json'][item]), 0, item + ' field empty' )
+    def test_03_redfish_v1_chassis_id_power(self):
+        errorlist = []
+        # Get list of nodes from the redfish Chassis API
+        api_data = fit_common.rackhdapi('/redfish/v1/Chassis')
+        self.assertEqual(api_data['status'], 200, 'Incorrect HTTP return code')
+        for nodeid in api_data['json']['Members']:
+            powerurl = nodeid['@odata.id'] + "/Power"
+            node = nodeid['@odata.id'].split('/')[-1]
+            if fit_common.VERBOSITY >= 2:
+                print ("Node ID: {} ".format(node))
+                print "Power url", powerurl
+            api_data = fit_common.rackhdapi(powerurl)
+            if api_data['status'] != 200:
+                errorlist.append("Nodeid: {} Bad return code {} for url: {}".format(node, api_data['status'], powerurl))
+            else:
+                # check required fields
+                for item in ['@odata.id', '@odata.type', 'Id']:
+                    if fit_common.VERBOSITY >= 2:
+                        print ("Checking: {0}".format(item))
+                    self.assertIn(item, api_data['json'], item + ' field not present')
+                    if fit_common.VERBOSITY >= 3:
+                        print ("\t {0}".format( api_data['json'][item]))
+                    self.assertGreater(len(api_data['json'][item]), 0, item + ' field empty' )
+        if errorlist:
+            print json.dumps(errorlist, indent=4)
+        self.assertEqual(errorlist, [], "Errors found".format(errorlist))
 
-    def test_redfish_v1_chassis_id_thermal(self):
-        #iterate through pre-qualified chassis
-        for nodeid in NODECATALOG:
-            api_data = fit_common.rackhdapi('/redfish/v1/Chassis/' + nodeid + '/Thermal')
-            self.assertEqual(api_data['status'], 200, 'Incorrect HTTP return code, expected 200, got:' + str(api_data['status']))
-            for item in ['@odata.type', '@odata.id', 'Id']:
-                if fit_common.VERBOSITY >= 2:
-                    print ("Checking: {0}".format(item))
-                self.assertIn(item, api_data['json'], item + ' field not present')
-                if fit_common.VERBOSITY >= 3:
-                    print ("\t {0}".format( api_data['json'][item]))
-                self.assertGreater(len(api_data['json'][item]), 0, item + ' field empty')
+    def test_04_redfish_v1_chassis_id_thermal(self):
+        errorlist = []
+        # Get list of Chassis from the stack
+        api_data = fit_common.rackhdapi('/redfish/v1/Chassis')
+        self.assertEqual(api_data['status'], 200, 'Incorrect HTTP return code')
+        for nodeid in api_data['json']['Members']:
+            thermalurl = nodeid['@odata.id'] + "/Thermal"
+            node = nodeid['@odata.id'].split('/')[-1]
+            if fit_common.VERBOSITY >= 2:
+                print ("Node ID: {} ".format(node))
+                print "Thermal url", thermalurl
+            api_data = fit_common.rackhdapi(thermalurl)
+            if api_data['status'] != 200:
+                errorlist.append("Nodeid: {} Bad return code {} for url: {}".format(node, api_data['status'], thermalurl))
+            else:
+                for item in ['@odata.type', '@odata.id', 'Id']:
+                    if fit_common.VERBOSITY >= 2:
+                        print ("Checking: {0}".format(item))
+                    self.assertIn(item, api_data['json'], item + ' field not present')
+                    if fit_common.VERBOSITY >= 3:
+                        print ("\t {0}".format( api_data['json'][item]))
+                    self.assertGreater(len(api_data['json'][item]), 0, item + ' field empty')
+        if errorlist:
+            print json.dumps(errorlist, indent=4)
+        self.assertEqual(errorlist, [], "Errors found".format(errorlist))
 
 if __name__ == '__main__':
     fit_common.unittest.main()


### PR DESCRIPTION
Updated the list of chassis used for the tests to pull from /redfish/v1/Chassis as opposed to the node select.  nodeselect gets a larger list of nodes that what is reported via the redfish API.  Redfish doesn't report the 'unsupported-compute' nodes when that SKU is installed.
Tested using valid and invalid APIs in the script before checking in.
```
Here's sample neg test:
(eh-fit-updates)hohene@lab02:~/sandbox-github/onrack2/tests.onrack2-eh-fit/test/
fit_tests/tests/redfish10$ python test_redfish10_api_chassis.py
..[
    "Nodeid: 57bb27356d6ef4250f2d53a9 Bad return code 404 for url: /redfish/v1/C
hassis/57bb27356d6ef4250f2d53a91/Power",
    "Nodeid: 57bb27716d6ef4250f2d53cb Bad return code 404 for url: /redfish/v1/C
hassis/57bb27716d6ef4250f2d53cb1/Power",
    "Nodeid: 57bb27716d6ef4250f2d53cb.57bb270fb59d512c0f33df81 Bad return code 4
04 for url: /redfish/v1/Chassis/57bb27716d6ef4250f2d53cb.57bb270fb59d512c0f33df8
11/Power",
    "Nodeid: 57bb27716d6ef4250f2d53cb.57bb270fb59d512c0f33df88 Bad return code 4
04 for url: /redfish/v1/Chassis/57bb27716d6ef4250f2d53cb.57bb270fb59d512c0f33df8
81/Power",
    "Nodeid: 57bb27716d6ef4250f2d53cb.57bb2710b59d512c0f33df8f Bad return code 4
04 for url: /redfish/v1/Chassis/57bb27716d6ef4250f2d53cb.57bb2710b59d512c0f33df8
f1/Power",
    "Nodeid: 57bb27716d6ef4250f2d53cb.57bb2714b59d512c0f33df96 Bad return code 4
04 for url: /redfish/v1/Chassis/57bb27716d6ef4250f2d53cb.57bb2714b59d512c0f33df9
61/Power",
    "Nodeid: 57bb27a36d6ef4250f2d53db Bad return code 404 for url: /redfish/v1/C
hassis/57bb27a36d6ef4250f2d53db1/Power"
]
F[
    "Nodeid: 57bb27356d6ef4250f2d53a9 Bad return code 404 for url: /redfish/v1/C
hassis/57bb27356d6ef4250f2d53a91/Thermal",
    "Nodeid: 57bb27716d6ef4250f2d53cb Bad return code 404 for url: /redfish/v1/C
hassis/57bb27716d6ef4250f2d53cb1/Thermal",
    "Nodeid: 57bb27716d6ef4250f2d53cb.57bb270fb59d512c0f33df81 Bad return code 4
04 for url: /redfish/v1/Chassis/57bb27716d6ef4250f2d53cb.57bb270fb59d512c0f33df8
11/Thermal",
    "Nodeid: 57bb27716d6ef4250f2d53cb.57bb270fb59d512c0f33df88 Bad return code 4
04 for url: /redfish/v1/Chassis/57bb27716d6ef4250f2d53cb.57bb270fb59d512c0f33df8
81/Thermal",
    "Nodeid: 57bb27716d6ef4250f2d53cb.57bb2710b59d512c0f33df8f Bad return code 4
04 for url: /redfish/v1/Chassis/57bb27716d6ef4250f2d53cb.57bb2710b59d512c0f33df8
f1/Thermal",
    "Nodeid: 57bb27716d6ef4250f2d53cb.57bb2714b59d512c0f33df96 Bad return code 4
04 for url: /redfish/v1/Chassis/57bb27716d6ef4250f2d53cb.57bb2714b59d512c0f33df9
61/Thermal",
    "Nodeid: 57bb27a36d6ef4250f2d53db Bad return code 404 for url: /redfish/v1/C
hassis/57bb27a36d6ef4250f2d53db1/Thermal"
]
F
======================================================================
FAIL: test_03_redfish_v1_chassis_id_power (__main__.redfish10_api_chassis)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_redfish10_api_chassis.py", line 87, in test_03_redfish_v1_chassis_i
d_power
    self.assertEqual(errorlist, [], "Errors found".format(errorlist))
AssertionError: Errors found

======================================================================
FAIL: test_04_redfish_v1_chassis_id_thermal (__main__.redfish10_api_chassis)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_redfish10_api_chassis.py", line 113, in test_04_redfish_v1_chassis_
id_thermal
    self.assertEqual(errorlist, [], "Errors found".format(errorlist))
AssertionError: Errors found

```