### PR TITLE
CAT-734: Adding get_auth_token() method

### DIFF
--- a/test/fit_tests/common/fit_common.py
+++ b/test/fit_tests/common/fit_common.py
@@ -20,6 +20,9 @@ import re
 import requests
 import pexpect
 import shutil
+import pycurl
+import StringIO
+import pprint
 
 # Globals
 
@@ -581,3 +584,71 @@ def run_nose(nosepath):
         exitcode += _noserunner(nosepath)
     return exitcode
 
+def get_auth_token(role=None, **endpoint):
+    '''
+    Returns authentication token using default credentials in the global config.
+    Obtaining the Admin token is the default, however, user can request the default ReadOnly as well as
+    user custom username, password and port via parameters.
+
+    :param role
+    :param endpoint dict with keys 'username', 'password' and 'port'
+    :return: string = {'stdout': str:ouput, 'exitcode': return code}
+    '''
+    # override obtaining credentials from GLOBAL_CONFIG, rather provide endpoint data
+    if endpoint:
+        if {'username', 'password', 'port'} <= set(endpoint):
+            username = endpoint['username']
+            password = endpoint['password']
+            port = endpoint['port']
+        else:
+            return ''
+    else:
+        port = 8443
+        if role is None or role in map(str.lower, ['Admin', 'Administrator']):
+            username = GLOBAL_CONFIG['credentials']['default_api_creds'][0]['admin_user'] # OnRack default admin usr
+            password = GLOBAL_CONFIG['credentials']['default_api_creds'][0]['admin_pass'] # OnRack default admin pwd
+        elif role in map(str.lower, ['ReadOnly']):
+            username = GLOBAL_CONFIG['credentials']['default_api_creds'][1]['readonly_user'] # OnRack default readonly usr
+            password = GLOBAL_CONFIG['credentials']['default_api_creds'][1]['readonly_pass'] # OnRack default readonly pwd
+        else:
+            return ''
+
+    if VERBOSITY >= 3:
+        print "retrieving authentication token using credentials and port: {{{0}, {1}, port={2}}}". \
+            format(username, password, port)
+
+    login_url = "https://{0}:{1}/login".format(ARGS_LIST['ora'], port)
+    login_payload = json.dumps({'username': username, 'password': password})
+    result = StringIO.StringIO()
+
+    c = pycurl.Curl()
+    c.setopt(pycurl.URL, login_url)
+    c.setopt(pycurl.VERBOSE, 0)
+    if VERBOSITY >= 9: c.setopt(pycurl.VERBOSE, 5)
+
+    # currently ignoring SSL certificate validation, ci-build ORA's currently do not have certs
+    c.setopt(pycurl.SSL_VERIFYPEER, False)
+    c.setopt(pycurl.SSL_VERIFYHOST, False)
+
+    c.setopt(pycurl.HTTPHEADER, ['Content-Type: application/json'])
+    c.setopt(pycurl.POST, 1)
+    c.setopt(pycurl.CONNECTTIMEOUT, 5)
+    c.setopt(pycurl.TIMEOUT, 8)
+    c.setopt(pycurl.POSTFIELDS, login_payload)
+    c.setopt(pycurl.WRITEDATA, result)
+
+    try:
+        c.perform()
+    except pycurl.error, error:
+        errno, errstr = error
+        print "ORA connectivity error occurred: ", errstr
+        return ''
+
+    # credential issue
+    if c.getinfo(pycurl.HTTP_CODE) in [400, 401]:
+        if VERBOSITY >= 3:
+            print "bad username or password, check GLOBAL_CONFIG or param endpoint values"
+        return  ''
+
+    dic = json.loads(result.getvalue())
+    return dic['token']

--- a/test/fit_tests/common/fit_common.py
+++ b/test/fit_tests/common/fit_common.py
@@ -595,15 +595,16 @@ def get_auth_token(role=None, **endpoint):
     :return: string = {'stdout': str:ouput, 'exitcode': return code}
     '''
     # override obtaining credentials from GLOBAL_CONFIG, rather provide endpoint data
+    token = None
     if endpoint:
         if {'username', 'password', 'port'} <= set(endpoint):
             username = endpoint['username']
             password = endpoint['password']
             port = endpoint['port']
         else:
-            return ''
+            return token
     else:
-        port = 8443
+        port = GLOBAL_CONFIG['ports']['https']
         if role is None or role in map(str.lower, ['Admin', 'Administrator']):
             username = GLOBAL_CONFIG['credentials']['default_api_creds'][0]['admin_user'] # OnRack default admin usr
             password = GLOBAL_CONFIG['credentials']['default_api_creds'][0]['admin_pass'] # OnRack default admin pwd
@@ -611,7 +612,7 @@ def get_auth_token(role=None, **endpoint):
             username = GLOBAL_CONFIG['credentials']['default_api_creds'][1]['readonly_user'] # OnRack default readonly usr
             password = GLOBAL_CONFIG['credentials']['default_api_creds'][1]['readonly_pass'] # OnRack default readonly pwd
         else:
-            return ''
+            return token
 
     if VERBOSITY >= 3:
         print "retrieving authentication token using credentials and port: {{{0}, {1}, port={2}}}". \
@@ -642,13 +643,13 @@ def get_auth_token(role=None, **endpoint):
     except pycurl.error, error:
         errno, errstr = error
         print "ORA connectivity error occurred: ", errstr
-        return ''
+        return token
 
     # credential issue
     if c.getinfo(pycurl.HTTP_CODE) in [400, 401]:
         if VERBOSITY >= 3:
             print "bad username or password, check GLOBAL_CONFIG or param endpoint values"
-        return  ''
+        return token
 
     dic = json.loads(result.getvalue())
     return dic['token']

--- a/test/fit_tests/common/fit_common.py
+++ b/test/fit_tests/common/fit_common.py
@@ -652,4 +652,9 @@ def get_auth_token(role=None, **endpoint):
         return token
 
     dic = json.loads(result.getvalue())
-    return dic['token']
+    if type(dic) is dict:
+        try:
+            token = dic['token']
+        except KeyError:
+            pass
+    return token

--- a/test/fit_tests/config/global_config.json
+++ b/test/fit_tests/config/global_config.json
@@ -48,7 +48,17 @@
         "username": "admn",
         "password": "admn"
       }
-    ]
+    ],
+    "default_api_creds": [
+      {
+         "admin_user": "admin",
+         "admin_pass": "admin123"
+      },
+      {
+         "readonly_user": "readonly",
+         "readonly_pass": "readonly123"
+      }
+   ]
   },
   "snmp":{
     "community": "onrack"

--- a/test/fit_tests/requirements.txt
+++ b/test/fit_tests/requirements.txt
@@ -5,3 +5,4 @@ pika==0.10.0
 nose==1.3.7
 proboscis==1.2.6.0
 pyvmomi==6.0.0.2016.6
+pycurl==7.19.3


### PR DESCRIPTION
@hohene @gpaulos 
Adding get_auth_token() method to fit_common

Test Run
(CAT-734_add_get_authentication_token_method) cuthbt1@socrates ~/sandbox/fit_tests/test/fit_tests $ python run_tests.py -stack 1 -test tests/bootstrap/torrey_function_test.py -v 3
get_auth_token test driver
==========================

get_auth_token() using global config
retrieving authentication token using credentials and port: {admin, admin123, port=8443}
my token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjoiYWRtaW4iLCJpYXQiOjE0NzIxNDk2NjAsImV4cCI6MTQ3MjIzNjA2MH0.Do1FYH5q8i92IC7yNyL5I_AtE4PmdsuaLOMXZohr57s


get_auth_token() using optional endpoint parameters (bad creds)
retrieving authentication token using credentials and port: {torrey1, torrey123, port=8443}
bad username or password, check GLOBAL_CONFIG or param endpoint values
Could not provide a token


get_auth_token() using optional endpoint parameters (good creds)
retrieving authentication token using credentials and port: {torrey, torrey123, port=8443}
my token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjoidG9ycmV5IiwiaWF0IjoxNDcyMTQ5NjYwLCJleHAiOjE0NzIyMzYwNjB9.tsKhOl_JrdsI-sLvlvXbppco6iHdfQQ6R2hXgzrY9dk
.
----------------------------------------------------------------------
Ran 1 test in 0.434s

OK