### PR TITLE
fix: ImportError (No module named run_onrack_smoke_test)

### DIFF
--- a/test/fit_tests/HWIMO-BUILD
+++ b/test/fit_tests/HWIMO-BUILD
@@ -20,7 +20,7 @@ INSTALL=${INSTALL-true}
 STACK_NUMBER=${STACK_NUMBER-}
 RELEASE_NAME=${RELEASE_NAME-onrack-devel}
 OVA_NAME=${OVA_NAME-None}
-TEST_SCRIPT=${TEST_SCRIPT-autotest/run_onrack_smoke_test.py}
+TEST_SCRIPT=${TEST_SCRIPT-deploy/run_onrack_smoke_test.py}
 TEST_RUN="smoketest"
 
 while true ; do


### PR DESCRIPTION
The default TEST_SCRIPT is "autotest/run_onrack_smoke_test.py".
The script run_onrack_smoke_test.py is placed in deploy folder rather than autotest which doesn't exist.
