### PR TITLE
Update pollers to include selEntries and update the error logging for running pollers.

### DIFF
--- a/test/fit_tests/tests/compute/test_rackhd11_computenode_pollers.py
+++ b/test/fit_tests/tests/compute/test_rackhd11_computenode_pollers.py
@@ -55,9 +55,9 @@ class rackhd11_computenode_pollers(fit_common.unittest.TestCase):
             print "\t{0}".format(msg)
 
         errorlist = []
-        poller_list = ['driveHealth', 'sel', 'chassis', 'selInformation', 'sdr']
+        poller_list = ['driveHealth', 'sel', 'chassis', 'selInformation', 'sdr', 'selEntries']
         if fit_common.VERBOSITY >= 2:
-            print "Expected Pollers for a Node: ".format(poller_list)
+            print "Expected Pollers for a Node: {} ".format(poller_list)
 
         for node in NODELIST:
             if fit_common.VERBOSITY >= 2:
@@ -73,7 +73,10 @@ class rackhd11_computenode_pollers(fit_common.unittest.TestCase):
                 if fit_common.VERBOSITY >= 3:
                     print "Poller list retreived", poller_dict
             else:
-                errorlist.append("Error: Node {0} Pollers not running {1}".format(node, list(set(poller_list) - set(poller_dict))))
+                if list(set(poller_list) - set(poller_dict)):
+                    errorlist.append("Error: Node {0} Pollers not running {1}".format(node, list(set(poller_list) - set(poller_dict))))
+                if list(set(poller_dict) - set(poller_list)):
+                    errorlist.append("Error: Node {0} Unexpected Pollers running {1}".format(node, list(set(poller_dict) - set(poller_list))))
 
         if errorlist != []:
             if fit_common.VERBOSITY >= 2:
@@ -87,7 +90,7 @@ class rackhd11_computenode_pollers(fit_common.unittest.TestCase):
             print "\t{0}".format(msg)
 
         errorlist = []
-        poller_list = ['driveHealth', 'sel', 'chassis', 'selInformation', 'sdr']
+        poller_list = ['driveHealth', 'sel', 'chassis', 'selInformation', 'sdr', 'selEntries']
         for node in NODELIST:
             if fit_common.VERBOSITY >= 2:
                 nodetype = get_rackhd_nodetype(node)

--- a/test/fit_tests/tests/compute/test_rackhd20_computenode_pollers.py
+++ b/test/fit_tests/tests/compute/test_rackhd20_computenode_pollers.py
@@ -53,7 +53,7 @@ class rackhd20_computenode_pollers(fit_common.unittest.TestCase):
             print "\t{0}".format(msg)
 
         errorlist = []
-        poller_list = ['driveHealth', 'sel', 'chassis', 'selInformation', 'sdr']
+        poller_list = ['driveHealth', 'sel', 'chassis', 'selInformation', 'sdr', 'selEntries']
         if fit_common.VERBOSITY >= 2:
             print "Expected Pollers for a Node: ".format(poller_list)
         for node in NODELIST:
@@ -70,7 +70,10 @@ class rackhd20_computenode_pollers(fit_common.unittest.TestCase):
                 if fit_common.VERBOSITY >= 3:
                     print "Poller list retreived", poller_dict
             else:
-                errorlist.append("Error: Node {0} Pollers not running {1}".format(node, list(set(poller_list) - set(poller_dict))))
+                if list(set(poller_list) - set(poller_dict)):
+                    errorlist.append("Error: Node {0} Pollers not running {1}".format(node, list(set(poller_list) - set(poller_dict))))
+                if list(set(poller_dict) - set(poller_list)):
+                    errorlist.append("Error: Node {0} Unexpected Pollers running {1}".format(node, list(set(poller_dict) - set(poller_list))))
 
         if errorlist != []:
             if fit_common.VERBOSITY >= 2:
@@ -84,7 +87,7 @@ class rackhd20_computenode_pollers(fit_common.unittest.TestCase):
             print "\t{0}".format(msg)
 
         errorlist = []
-        poller_list = ['driveHealth', 'sel', 'chassis', 'selInformation', 'sdr']
+        poller_list = ['driveHealth', 'sel', 'chassis', 'selInformation', 'sdr', 'selEntries']
         for node in NODELIST:
             if fit_common.VERBOSITY >= 2:
                 nodetype = get_rackhd_nodetype(node)


### PR DESCRIPTION
Here's sample output.
Passing test:
```
(eh-master)hohene@lab02:~/sandbox-github/onrack2/tests.onrack2-eh-fit/test/fit_tests$ run_tests.py -stack 12 -v 2 -test tests/compute/test_rackhd11_computenode_po
llers.py:rackhd11_computenode_pollers.test_1_verify_pollers
	Description: Check pollers created for node
Expected Pollers for a Node: ['driveHealth', 'sel', 'chassis', 'selInformation', 'sdr', 'selEntries'] 
Node: 57e546bfc00016bc058322c6  Type: Dell R630
Expected pollers instantiated on node
Node: 57e546eec00016bc058322d4  Type: Quanta T41
Expected pollers instantiated on node
Node: 57e546dec00016bc058322cd  Type: Hydra
Expected pollers instantiated on node
Node: 57e547dcc00016bc058322e5  Type: Quanta T41
Expected pollers instantiated on node
Node: 57e547dcc00016bc058322e4  Type: Quanta T41
Expected pollers instantiated on node
Node: 57e547dfc00016bc058322f2  Type: Quanta T41
Expected pollers instantiated on node
Node: 57e5755c5942440b18645b1b  Type: Rinjin TP
Expected pollers instantiated on node
.
----------------------------------------------------------------------
Ran 1 test in 0.646s
```
Test with extra and missing pollers:
```
(eh-master)hohene@lab02:~/sandbox-github/onrack2/tests.onrack2-eh-fit/test/fit_tests$ run_tests.py -stack 12 -v 2 -test tests/compute/test_rackhd11_computenode_po
llers.py:rackhd11_computenode_pollers.test_1_verify_pollers
	Description: Check pollers created for node
Expected Pollers for a Node: ['driveHealth', 'sel', 'chassis', 'selInformation', 'Erikas'] 
Node: 57e546bfc00016bc058322c6  Type: Dell R630
Node: 57e546eec00016bc058322d4  Type: Quanta T41
Node: 57e546dec00016bc058322cd  Type: Hydra
Node: 57e547dcc00016bc058322e5  Type: Quanta T41
Node: 57e547dcc00016bc058322e4  Type: Quanta T41
Node: 57e547dfc00016bc058322f2  Type: Quanta T41
Node: 57e5755c5942440b18645b1b  Type: Rinjin TP
[
    "Error: Node 57e546bfc00016bc058322c6 Pollers not running ['Erikas']", 
    "Error: Node 57e546bfc00016bc058322c6 Unexpected Pollers running [u'selEntries', u'sdr']", 
    "Error: Node 57e546eec00016bc058322d4 Pollers not running ['Erikas']", 
    "Error: Node 57e546eec00016bc058322d4 Unexpected Pollers running [u'selEntries', u'sdr']", 
    "Error: Node 57e546dec00016bc058322cd Pollers not running ['Erikas']", 
    "Error: Node 57e546dec00016bc058322cd Unexpected Pollers running [u'selEntries', u'sdr']", 
    "Error: Node 57e547dcc00016bc058322e5 Pollers not running ['Erikas']", 
    "Error: Node 57e547dcc00016bc058322e5 Unexpected Pollers running [u'selEntries', u'sdr']", 
    "Error: Node 57e547dcc00016bc058322e4 Pollers not running ['Erikas']", 
    "Error: Node 57e547dcc00016bc058322e4 Unexpected Pollers running [u'selEntries', u'sdr']", 
    "Error: Node 57e547dfc00016bc058322f2 Pollers not running ['Erikas']", 
    "Error: Node 57e547dfc00016bc058322f2 Unexpected Pollers running [u'selEntries', u'sdr']", 
    "Error: Node 57e5755c5942440b18645b1b Pollers not running ['Erikas']", 
    "Error: Node 57e5755c5942440b18645b1b Unexpected Pollers running [u'selEntries', u'sdr']"
]
F
```