### PR TITLE
check poller updates in stack init scripts

### DIFF
--- a/test/fit_tests/deploy/onrack_stack_init.py
+++ b/test/fit_tests/deploy/onrack_stack_init.py
@@ -16,20 +16,30 @@ import fit_common
 import pdu_lib
 
 # Locals
-MAX_CYCLES = 60
+MAX_CYCLES = 80
 
 class onrack_stack_init(fit_common.unittest.TestCase):
-    # Temporary auth settings routine
-    def test00_set_auth_user(self):
-        print '**** Installing default admin user'
-        fit_common.remote_shell('rm auth.json')
-        auth_json = open('auth.json', 'w')
-        auth_json.write('{"username":"' + fit_common.GLOBAL_CONFIG["api"]["admin_user"] + '", "password":"' + fit_common.GLOBAL_CONFIG["api"]["admin_pass"] + '", "role":"Administrator"}')
-        auth_json.close()
-        fit_common.scp_file_to_ora('auth.json')
-        rc = fit_common.remote_shell("curl -ks -X POST -H 'Content-Type:application/json' https://localhost:" + str(fit_common.GLOBAL_CONFIG['ports']['https']) + "/api/2.0/users -d @auth.json" )
-        if rc['exitcode'] != 0:
-            print "ALERT: Auth admin user not set! Please manually set the admin user account if https access is desired."
+
+    def test00_update_config(self):
+        # this will add proxy settings to default OnRack Config file
+        monorail_config = fit_common.rackhdapi('/api/2.0/config')['json']
+        monorail_config.update(
+                    {"httpProxies": [{
+                        "localPath": "/mirror",
+                        "remotePath": "/",
+                        "server": fit_common.GLOBAL_CONFIG['repos']['mirror']
+                    }]}
+                    )
+        monorail_json = open('monorail.json', 'w')
+        monorail_json.write(fit_common.json.dumps(monorail_config, sort_keys=True, indent=4))
+        monorail_json.close()
+        fit_common.scp_file_to_ora('monorail.json')
+        self.assertEqual(fit_common.remote_shell('cp monorail.json /opt/onrack/etc/')['exitcode'], 0, "RackHD Config file failure.")
+        os.remove('monorail.json')
+        print "**** Restart services..."
+        fit_common.remote_shell("/opt/onrack/bin/monorail restart")
+        fit_common.countdown(30)
+        self.assertEqual(fit_common.rackhdapi("/api/2.0/config")['status'], 200, "Unable to contact Onrack.")
 
     def test01_preload_default_sku(self):
         # Load default SKU for unsupported compute nodes
@@ -145,7 +155,7 @@ class onrack_stack_init(fit_common.unittest.TestCase):
                 discovery_complete = True
 
                 for node in nodes_data['json']:
-                    if node['type'] == 'compute':
+                    if node['type'] == 'compute' and node.get('sku'):
                         self.assertIn('id', node, 'node does not contain id')
                         node_id = node['id']
                         # determine if there are any active worlflows. If so, discovery not completed
@@ -266,6 +276,7 @@ class onrack_stack_init(fit_common.unittest.TestCase):
                     print '**** Missing node:' + entry['sku'] + "  BMC:" + entry['bmcmac']
                     errorlist.append(entry['bmcmac'])
             self.assertEqual(errorlist, [], "Missing nodes in catalog.")
+
 
 if __name__ == '__main__':
     fit_common.unittest.main()

--- a/test/fit_tests/deploy/rackhd_stack_init.py
+++ b/test/fit_tests/deploy/rackhd_stack_init.py
@@ -44,7 +44,7 @@ class rackhd_stack_init(fit_common.unittest.TestCase):
         for subdir, dirs, files in os.walk('on-skupack/tarballs'):
             for skupacks in files:
                 print "\n**** Loading SKU Pack for " + skupacks
-                fit_common.rackhdapi("/api/2.0/skus/pack", action="binary-post",
+                fit_common.rackhdapi("/api/1.1/skus/pack", action="binary-post",
                                      payload=file(fit_common.TEST_PATH + "on-skupack/tarballs/" + skupacks).read())
             break
         print "\n"
@@ -272,18 +272,28 @@ class rackhd_stack_init(fit_common.unittest.TestCase):
         :return:  True  - Poller have data
                   False - Not all poller have data
         '''
+        poller_list = []
         api_data = fit_common.rackhdapi('/api/2.0/pollers')
         if api_data:
-            for dummy in range(0, max_time):
-                good_poller_data = True
-                for index in  api_data['json']:
-                    poll_data = fit_common.rackhdapi("/api/2.0/pollers/" + index['id'] + "/data")
-                    if poll_data['status'] != 200 or len(poll_data['json']) == 0:
-                        good_poller_data = False
-                        break
-                if good_poller_data:
-                    return True
-                fit_common.time.sleep(10)
+            # set up a list of poller ids
+            for index in api_data['json']:
+                poller_list.append(index['id'])
+            if poller_list != []:
+                for dummy in range(0, max_time):
+                    # move backwards through the list allowing completed poller ids to be popped 
+                    # off the list
+                    for i in reversed(range(len(poller_list))):
+                        id = poller_list[i]
+                        poll_data = fit_common.rackhdapi("/api/2.0/pollers/" + id + "/data/current")
+                        # Check if data current returned 200 and data in the poll, if so, remove from list
+                        if poll_data['status'] == 200 and len(poll_data['json']) != 0:
+                            poller_list.pop(i)
+                    if poller_list == []:
+                        # return when all pollers look good
+                        return True
+                    fit_common.time.sleep(10)
+        if poller_list != []:
+            print "Poller IDs with error or no data: {}".format(fit_common.json.dumps(poller_list, indent=4))
         return False
 
 if __name__ == '__main__':

--- a/test/fit_tests/deploy/rackhd_stack_init.py
+++ b/test/fit_tests/deploy/rackhd_stack_init.py
@@ -44,7 +44,7 @@ class rackhd_stack_init(fit_common.unittest.TestCase):
         for subdir, dirs, files in os.walk('on-skupack/tarballs'):
             for skupacks in files:
                 print "\n**** Loading SKU Pack for " + skupacks
-                fit_common.rackhdapi("/api/1.1/skus/pack", action="binary-post",
+                fit_common.rackhdapi("/api/2.0/skus/pack", action="binary-post",
                                      payload=file(fit_common.TEST_PATH + "on-skupack/tarballs/" + skupacks).read())
             break
         print "\n"
@@ -264,6 +264,7 @@ class rackhd_stack_init(fit_common.unittest.TestCase):
                 return True
             fit_common.time.sleep(30)
         return False
+
 
     def check_for_active_poller_data(self, max_time):
         '''

--- a/test/fit_tests/tests/compute/test_rackhd20_computenode_pollers.py
+++ b/test/fit_tests/tests/compute/test_rackhd20_computenode_pollers.py
@@ -3,7 +3,7 @@ Copyright 2016, EMC, Inc.
 
 Author(s):
 
-This test checks pollers under API 1.1
+This test checks pollers under API 2.0
 '''
 
 
@@ -41,7 +41,7 @@ def get_rackhd_nodetype(nodeid):
             else:
                 nodetype = skudata['json'].get("name")
         else:
-            print "Error: nodeid {} did not return a valid sku in get_rackhd_nodetype{}".format(nodeid, sku)
+            print "Error: nodeid {} did not return a valid sku in get_rackhd_nodetype {}".format(nodeid, sku)
     return nodetype
 
 from nose.plugins.attrib import attr
@@ -55,7 +55,7 @@ class rackhd20_computenode_pollers(fit_common.unittest.TestCase):
         errorlist = []
         poller_list = ['driveHealth', 'sel', 'chassis', 'selInformation', 'sdr', 'selEntries']
         if fit_common.VERBOSITY >= 2:
-            print "Expected Pollers for a Node: ".format(poller_list)
+            print "Expected Pollers for a Node: {}".format(poller_list)
         for node in NODELIST:
             if fit_common.VERBOSITY >= 2:
                 nodetype = get_rackhd_nodetype(node)
@@ -71,9 +71,9 @@ class rackhd20_computenode_pollers(fit_common.unittest.TestCase):
                     print "Poller list retreived", poller_dict
             else:
                 if list(set(poller_list) - set(poller_dict)):
-                    errorlist.append("Error: Node {0} Pollers not running {1}".format(node, list(set(poller_list) - set(poller_dict))))
+                    errorlist.append("Error: Node {} Pollers not running {}".format(node, list(set(poller_list) - set(poller_dict))))
                 if list(set(poller_dict) - set(poller_list)):
-                    errorlist.append("Error: Node {0} Unexpected Pollers running {1}".format(node, list(set(poller_dict) - set(poller_list))))
+                    errorlist.append("Error: Node {} Unexpected Pollers running {}".format(node, list(set(poller_dict) - set(poller_list))))
 
         if errorlist != []:
             if fit_common.VERBOSITY >= 2:
@@ -148,7 +148,7 @@ class rackhd20_computenode_pollers(fit_common.unittest.TestCase):
             self.assertEqual(errorlist, [], "Error reported.")
 
     def test_4_poller_default_cache(self):
-        msg = "Description: Check number of polls being kept for poller ID"
+        msg = "Description: Check number of polls being kept for poller ID, should not exceed 10"
         if fit_common.VERBOSITY >= 2:
             print "\t{0}".format(msg)
 
@@ -236,7 +236,7 @@ class rackhd20_computenode_pollers(fit_common.unittest.TestCase):
             self.assertEqual(errorlist, [], "Error reported.")
 
     def test_7_nodes_id_pollers(self):
-        msg = "Description: Display the poller updated-at per node."
+        msg = "Description: Display the poller last-finished per node."
         if fit_common.VERBOSITY >= 2:
             print "\t{0}".format(msg)
 
@@ -260,8 +260,9 @@ class rackhd20_computenode_pollers(fit_common.unittest.TestCase):
                 poll_data = fit_common.rackhdapi("/api/2.0/pollers/" + poller_id)
                 if fit_common.VERBOSITY >= 2:
                     print "Poller: {}  ID: {} ".format(poller, str(poller_id))
-                    print "Created At: {}".format(fit_common.json.dumps(poll_data['json'].get('createdAt')))
-                    print "Updated At: {}".format(fit_common.json.dumps(poll_data['json'].get('updatedAt')))
+                    print "Last Started: {}".format(fit_common.json.dumps(poll_data['json'].get('lastStarted')))
+                    print "Last Finished: {}".format(fit_common.json.dumps(poll_data['json'].get('lastFinished')))
+                    print "Paused: {}".format(fit_common.json.dumps(poll_data['json'].get('paused')))
         if errorlist != []:
             if fit_common.VERBOSITY >= 2:
                 print "{}".format(fit_common.json.dumps(errorlist, indent=4))


### PR DESCRIPTION
Updated the check_pollers test
- changed it to pull the current data from a poll instead of all data  - /api/2.0/pollers/xx/data/current
- changed it to use a list of poller ids and once the poller returns good data, stop checking that id

Fixed some typos in the compute node poller 2.0 script